### PR TITLE
fix: check `caches` if it's available

### DIFF
--- a/src/remix.ts
+++ b/src/remix.ts
@@ -26,7 +26,8 @@ export const createGetLoadContextArgs = (c: Context) => {
         ctx: {
           ...c.executionCtx,
         },
-        caches,
+        // @ts-expect-error globalThis.caches is not typed
+        caches: globalThis.caches ? caches : undefined,
       },
     },
     request: c.req.raw,


### PR DESCRIPTION
The dev server was throwing an error if `adapter` from `@hono/vite-dev-server/cloudflare` is not applied. Avoiding it.