### PR TITLE
feat: Support for asynchronous `getLoadContext`

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -23,7 +23,7 @@ export const handle = (userApp?: Hono, options?: Options) => {
     const args = createGetLoadContextArgs(c)
 
     const remixContext = getLoadContext(args)
-    return handler(c.req.raw, remixContext)
+    return handler(c.req.raw, remixContext instanceof Promise ? await remixContext : remixContext)
   })
 
   return app

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -11,7 +11,7 @@ export type GetLoadContext = (args: {
 }) => AppLoadContext | Promise<AppLoadContext>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const defaultGetLoadContext = ({ context }: any) => {
+export const defaultGetLoadContext = ({ context }: any): AppLoadContext => {
   return {
     ...context,
   }

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -8,7 +8,7 @@ export type GetLoadContext = (args: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     cloudflare: any
   }
-}) => AppLoadContext
+}) => AppLoadContext | Promise<AppLoadContext>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const defaultGetLoadContext = ({ context }: any) => {


### PR DESCRIPTION
Related #21 

Support for asynchronous `getLoadContext`.
The `getLoadContext` function is already awaited in [`src/middleware.ts` at line 21](https://github.com/yusukebe/hono-remix-adapter/blob/main/src/middleware.ts#L21).
Therefore, we only need to support the type that returns `Promise<AppLoadContext>`.

※ 英語に自信がないので、日本語でも説明します。
非同期の `getLoadContext` のサポート。
`getLoadContext` 関数はすでに [`src/middleware.ts`の21行目](https://github.com/yusukebe/hono-remix-adapter/blob/main/src/middleware.ts#L21)でawaitされています。
そのため、`GetLoadContext` 型が `Promise<AppLoadContext>` を返せるようにすればよいです。