### PR TITLE
fix: Fix node adpater requiring cloudflare dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       ],
       "dependencies": {
         "@hono/vite-dev-server": "^0.17.0",
+        "@remix-run/server-runtime": "^2.15.0",
         "remix-hono": "^0.0.16"
       },
       "devDependencies": {
@@ -2554,6 +2555,31 @@
         }
       }
     },
+    "node_modules/@remix-run/cloudflare/node_modules/@remix-run/server-runtime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
+      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
+      "dependencies": {
+        "@remix-run/router": "1.21.0",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/dev": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.14.0.tgz",
@@ -3019,6 +3045,32 @@
         "node": ">=12"
       }
     },
+    "node_modules/@remix-run/dev/node_modules/@remix-run/server-runtime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
+      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/router": "1.21.0",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/dev/node_modules/esbuild": {
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.6.tgz",
@@ -3301,6 +3353,31 @@
         }
       }
     },
+    "node_modules/@remix-run/node/node_modules/@remix-run/server-runtime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
+      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
+      "dependencies": {
+        "@remix-run/router": "1.21.0",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/node/node_modules/undici": {
       "version": "6.20.1",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
@@ -3328,6 +3405,31 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/react/node_modules/@remix-run/server-runtime": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
+      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
+      "dependencies": {
+        "@remix-run/router": "1.21.0",
+        "@types/cookie": "^0.6.0",
+        "@web3-storage/multipart-parser": "^1.0.0",
+        "cookie": "^0.6.0",
+        "set-cookie-parser": "^2.4.8",
+        "source-map": "^0.7.3",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -3368,10 +3470,9 @@
       }
     },
     "node_modules/@remix-run/server-runtime": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.14.0.tgz",
-      "integrity": "sha512-9Th9UzDaoFFBD7zA5mRI1KT8JktFLN4ij9jPygrKBhG/kYmNIvhcMtq9VyjcbMvFK5natTyhOhrrKRIHtijD4w==",
-      "license": "MIT",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/server-runtime/-/server-runtime-2.15.0.tgz",
+      "integrity": "sha512-FuM8vAg1sPskf4wn0ivbuj/7s9Qdh2wnKu+sVXqYz0a95gH5b73TuMzk6n3NMSkFVKKc6+UmlG1WLYre7L2LTg==",
       "dependencies": {
         "@remix-run/router": "1.21.0",
         "@types/cookie": "^0.6.0",
@@ -14205,7 +14306,6 @@
           "url": "https://github.com/sponsors/sergiodxa"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@remix-run/server-runtime": "^2.6.0",
         "hono": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@hono/vite-dev-server": "^0.17.0",
+    "@remix-run/server-runtime": "^2.15.0",
     "remix-hono": "^0.0.16"
   },
   "peerDependencies": {

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -16,7 +16,7 @@ export const handle = (userApp?: Hono, options?: Options) => {
   app.all('*', async (c) => {
     // @ts-expect-error it's not typed
     const build = await import('virtual:remix/server-build')
-    const { createRequestHandler } = await import('@remix-run/cloudflare')
+    const { createRequestHandler } = await import('@remix-run/server-runtime')
     const handler = createRequestHandler(build, 'development')
 
     const getLoadContext = options?.getLoadContext ?? defaultGetLoadContext


### PR DESCRIPTION
Rel https://github.com/yusukebe/hono-remix-adapter/issues/34

**Issue**
Running the package with the node adapter, requires `@remix-run/cloudflare`

**Fix**
Replace the  `@remix-run/cloudflare` with `@remix-run/server-runtime`, since it's dev env it shouldn't be much of an issue