### PR TITLE
fix: Remove remix-hono dependency

### DIFF
--- a/examples/cloudflare-pages/package.json
+++ b/examples/cloudflare-pages/package.json
@@ -19,8 +19,7 @@
     "hono": "^4.5.11",
     "isbot": "^4.1.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "remix-hono": "^0.0.16"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@hono/vite-dev-server": "^0.16.0",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -19,8 +19,7 @@
     "hono": "^4.6.9",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "remix-hono": "^0.0.16"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@hono/vite-dev-server": "^0.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,8 +80,7 @@
         "hono": "^4.5.11",
         "isbot": "^4.1.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "remix-hono": "^0.0.16"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@hono/vite-dev-server": "^0.16.0",
@@ -405,8 +404,7 @@
         "hono": "^4.6.9",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "remix-hono": "^0.0.16"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@hono/vite-dev-server": "^0.16.0",
@@ -13670,18 +13668,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-cache-header": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-cache-header/-/pretty-cache-header-1.0.0.tgz",
-      "integrity": "sha512-xtXazslu25CdnGnUkByU1RoOjK55TqwatJkjjJLg5ZAdz2Lngko/mmaUgeET36P2GMlNwh3fdM7FWBO717pNcw==",
-      "license": "MIT",
-      "dependencies": {
-        "timestring": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12.13"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -14293,42 +14279,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remix-hono": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/remix-hono/-/remix-hono-0.0.16.tgz",
-      "integrity": "sha512-IPooI2E0eSFRV9wAgTzpsklSoOyij6Nsk6ANIugGhD9vYlovbYb2BT+siz++sLzWseZSPEtIzx/LBel203jBfQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sergiodxa"
-        }
-      ],
-      "dependencies": {
-        "@remix-run/server-runtime": "^2.6.0",
-        "hono": "^4.0.0",
-        "pretty-cache-header": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@remix-run/cloudflare": "^2.0.0",
-        "i18next": "^23.0.0",
-        "remix-i18next": "^6.0.0",
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/cloudflare": {
-          "optional": true
-        },
-        "i18next": {
-          "optional": true
-        },
-        "remix-i18next": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/require-like": {
@@ -15760,15 +15710,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/timestring": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
-      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/tinybench": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
       ],
       "dependencies": {
         "@hono/vite-dev-server": "^0.17.0",
-        "@remix-run/server-runtime": "^2.15.0",
-        "remix-hono": "^0.0.16"
+        "@remix-run/server-runtime": "^2.15.0"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.4.23",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
   },
   "dependencies": {
     "@hono/vite-dev-server": "^0.17.0",
-    "@remix-run/server-runtime": "^2.15.0",
-    "remix-hono": "^0.0.16"
+    "@remix-run/server-runtime": "^2.15.0"
   },
   "peerDependencies": {
     "hono": "*"

--- a/src/handlers/cloudflare-pages.ts
+++ b/src/handlers/cloudflare-pages.ts
@@ -1,7 +1,6 @@
 import { Hono } from 'hono'
 import { handle } from 'hono/cloudflare-pages'
-import { staticAssets } from 'remix-hono/cloudflare'
-import { remix } from '../middleware'
+import { remix, staticAssets } from '../middleware'
 import { defaultGetLoadContext } from '../remix'
 import type { GetLoadContext } from '../remix'
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,3 +22,45 @@ export const remix = ({ mode, build, getLoadContext }: RemixMiddlewareOptions) =
     )
   })
 }
+
+
+/**
+* A string of directives for the Cache-Control header.
+* See the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) docs for more information.
+*/
+
+type CacheControl= string;
+
+interface StaticAssetsOptions {
+	cache?: CacheControl;
+}
+
+export function staticAssets(options: StaticAssetsOptions = {}) {
+	return createMiddleware(async (c, next) => {
+		let binding = c.env?.ASSETS as Fetcher | undefined;
+
+		if (!binding) throw new ReferenceError("The binding ASSETS is not set.");
+
+		let response: Response;
+
+		c.req.raw.headers.delete("if-none-match");
+
+		try {
+			response = await binding.fetch(c.req.url, c.req.raw.clone());
+
+			// If the request failed, we just call the next middleware
+			if (response.status >= 400) return await next();
+
+			response = new Response(response.body, response);
+
+			// If cache options are configured, we set the cache-control header
+			if (options.cache) {
+				response.headers.set("cache-control", );
+			}
+
+			return response;
+		} catch {
+			return await next();
+		}
+	});
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,44 +23,47 @@ export const remix = ({ mode, build, getLoadContext }: RemixMiddlewareOptions) =
   })
 }
 
-
 /**
-* A string of directives for the Cache-Control header.
-* See the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) docs for more information.
-*/
+ * A string of directives for the Cache-Control header.
+ * See the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) docs for more information.
+ */
 
-type CacheControl= string;
+type CacheControl = string
 
 interface StaticAssetsOptions {
-	cache?: CacheControl;
+  cache?: CacheControl
 }
 
 export function staticAssets(options: StaticAssetsOptions = {}) {
-	return createMiddleware(async (c, next) => {
-		let binding = c.env?.ASSETS as Fetcher | undefined;
+  return createMiddleware(async (c, next) => {
+    const binding = c.env?.ASSETS as Fetcher | undefined
 
-		if (!binding) throw new ReferenceError("The binding ASSETS is not set.");
+    if (!binding) {
+      throw new ReferenceError('The binding ASSETS is not set.')
+    }
 
-		let response: Response;
+    let response: Response
 
-		c.req.raw.headers.delete("if-none-match");
+    c.req.raw.headers.delete('if-none-match')
 
-		try {
-			response = await binding.fetch(c.req.url, c.req.raw.clone());
+    try {
+      response = await binding.fetch(c.req.url, c.req.raw.clone())
 
-			// If the request failed, we just call the next middleware
-			if (response.status >= 400) return await next();
+      // If the request failed, we just call the next middleware
+      if (response.status >= 400) {
+        return await next()
+      }
 
-			response = new Response(response.body, response);
+      response = new Response(response.body, response)
 
-			// If cache options are configured, we set the cache-control header
-			if (options.cache) {
-				response.headers.set("cache-control", );
-			}
+      // If cache options are configured, we set the cache-control header
+      if (options.cache) {
+        response.headers.set('cache-control', options.cache)
+      }
 
-			return response;
-		} catch {
-			return await next();
-		}
-	});
+      return response
+    } catch {
+      return await next()
+    }
+  })
 }


### PR DESCRIPTION
Removes `remix-hono` as a dependency to allow for a smoother upgrade to react-router 7