### PR TITLE
docs: Add Hono installation step to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This means you can create API routes with Hono's syntax and use a lot of Hono's 
 ## Install
 
 ```bash
-npm i hono-remix-adapter
+npm i hono-remix-adapter hono
 ```
 
 ## How to use


### PR DESCRIPTION
It might be obvious to existing users but adding hono-remix-adapter to an existing Remix app requires the hono package to also be installed.